### PR TITLE
fix the metric_type key in the example config

### DIFF
--- a/exporter_config.yaml
+++ b/exporter_config.yaml
@@ -25,7 +25,7 @@ metrics:
         threshold: 10
         tag_value: other
     # Allowed values for metric type are AmortizedCost, BlendedCost, NetAmortizedCost, NetUnblendedCost, NormalizedUsageAmount, UnblendedCost, and UsageQuantity
-    metrics_type: AmortizedCost
+    metric_type: AmortizedCost
 
   - metric_name: aws_daily_cost_usd # change the metric name if needed
     group_by:
@@ -45,7 +45,7 @@ metrics:
         threshold: 10
         tag_value: other
     # Allowed values for metric type are AmortizedCost, BlendedCost, NetAmortizedCost, NetUnblendedCost, NormalizedUsageAmount, UnblendedCost, and UsageQuantity
-    metrics_type: AmortizedCost
+    metric_type: AmortizedCost
 
 target_aws_accounts:
   # here defines a list of target AWS accounts


### PR DESCRIPTION
In the config file, it should be `metric_type` instead of `metrics_type` after the refactoring in #16 .