### PR TITLE
feat: introduce mapped aliases

### DIFF
--- a/exporter_config.yaml
+++ b/exporter_config.yaml
@@ -19,6 +19,12 @@ metrics:
         - type: DIMENSION
           key: LINKED_ACCOUNT
           label_name: AccountName
+          alias: # optional - this will allow you to add label alias to with mapped values (both original and aliased labels will be exported)
+            label_name: AccountAlias
+            map:
+              "123456789012": "myaccount"
+              "234567890123": "publisher1"
+              "321645789123": "publisher2"
       merge_minor_cost:
         # if this is enabled, minor cost that is below the threshold will be merged into one group
         enabled: false

--- a/main.py
+++ b/main.py
@@ -76,8 +76,30 @@ def validate_configs(config):
                 if group["label_name"] in group_label_names:
                     logging.error("Group label names should be unique!")
                     sys.exit(1)
-                else:
-                    group_label_names.add(group["label_name"])
+
+                if "alias" in group:
+                    if group["type"] != "DIMENSION":
+                        logging.error("Group with alias must be a dimension!")
+                        sys.exit(1)
+                    if "label_name" not in group["alias"]:
+                        logging.error("Group alias must have a label_name!")
+                        sys.exit(1)
+                    if "map" not in group["alias"]:
+                        logging.error("Group alias must have a mapping!")
+                        sys.exit(1)
+                    if group["alias"]["label_name"] in group_label_names:
+                        logging.error("Group label names and aliases should be unique!")
+                        sys.exit(1)
+                    if group["label_name"] == group["alias"]["label_name"]:
+                        logging.error("Group label name and alias name cannot be the same!")
+                        sys.exit(1)
+                    if not isinstance(group["alias"]["map"], dict):
+                        logging.error("Group alias map must be a dictionary!")
+                        sys.exit(1)
+
+                    group_label_names.add(group["alias"]["label_name"])
+
+                group_label_names.add(group["label_name"])
 
             if group_label_names & set(labels):
                 logging.error("Some label names in group_by are the same as AWS account labels!")


### PR DESCRIPTION
Hi, I would like to introduce support for the `alias` label for groups. This can be used, for example, to map AWS account IDs to more human-readable names.

I apologize for any possible bugs or misconceptions, since Python is not one of my primary programming languages.