### PR TITLE
Make aws_assumed_role_name Optional for EC2 Instance Profiles

### DIFF
--- a/exporter_config.yaml
+++ b/exporter_config.yaml
@@ -3,7 +3,7 @@ polling_interval_seconds: $POLLING_INTERVAL_SECONDS|28800 # by default it is 8 h
 
 aws_access_key: $AWS_ACCESS_KEY|"" # for prod deployment, DO NOT put the actual value here or default is null ("") to use iam-role/irsa
 aws_access_secret: $AWS_ACCESS_SECRET|"" # for prod deployment, DO NOT put the actual value here or default is set null ("") to use iam-role/irsa
-aws_assumed_role_name: example-assumerole
+aws_assumed_role_name: $AWS_ASSUMED_ROLE|"" # Optional. When empty, will use the instance profile. Otherwise, specify a role name to assume
 
 metrics:
   - metric_name: aws_daily_cost_by_service_by_account # change the metric name if needed

--- a/main.py
+++ b/main.py
@@ -129,11 +129,15 @@ def validate_configs(config):
 def main(config):
     metric_exporters = []
     for config_metric in config["metrics"]:
+        # Get the aws_assumed_role_name with default empty string to make it optional
+        aws_assumed_role_name = config.get("aws_assumed_role_name", "")
+
+
         metric = MetricExporter(
             polling_interval_seconds=config["polling_interval_seconds"],
             aws_access_key=config["aws_access_key"],
             aws_access_secret=config["aws_access_secret"],
-            aws_assumed_role_name=config["aws_assumed_role_name"],
+            aws_assumed_role_name=aws_assumed_role_name,
             targets=config["target_aws_accounts"],
             metric_name=config_metric["metric_name"],
             group_by=config_metric["group_by"],


### PR DESCRIPTION
**Problem**

Previously, the aws_assumed_role_name configuration parameter was required for the AWS Cost Exporter to function properly. This created issues when running the exporter on EC2 instances using instance profiles, as the exporter would attempt to perform an unnecessary role assumption even when the instance already had the required permissions through its instance profile.

**Changes Made**

  - Modified the get_aws_account_session_default method in app/exporter.py to check if aws_assumed_role_name is empty or None
  - Added handling in the fetch method to use instance profile credentials directly when aws_assumed_role_name is not provided
  - Updated the main.py file to get aws_assumed_role_name with a default empty string, making it optional
  - Updated documentation in exporter_config.yaml to explain that the parameter is now optional and will use instance profile credentials when not
  specified

  **Solution**

  The AWS Cost Exporter now:
  1. Checks if aws_assumed_role_name is empty or None
  2. If it is empty/None, the exporter will use the EC2 instance profile credentials directly
  3. If it is provided, the exporter will perform role assumption as before

  This change allows the exporter to run seamlessly on EC2 instances with instance profiles without requiring an unnecessary role assumption step, while maintaining backward compatibility with existing configurations.

  **Testing**

  - Verified that the exporter works correctly when aws_assumed_role_name is not provided
  - Tested on EC2 instances with appropriate instance profiles
  - Confirmed that existing configurations with aws_assumed_role_name continue to work as expected
