### PR TITLE
ensure tag filters are passed to the metric exporter class

### DIFF
--- a/main.py
+++ b/main.py
@@ -175,6 +175,7 @@ def main(config):
             group_by=config_metric["group_by"],
             metric_type=config_metric["metric_type"],
             record_types=config_metric.get("record_types", ["Usage"]),
+            tag_filters=config_metric.get("tag_filters", None)
         )
         metric_exporters.append(metric)
 


### PR DESCRIPTION

Hi,

Thanks for the great work on this.   I've found a minor issue where the `tag_filters` is not passed to the `MetricExporter` class.    This pull request fixes that and allows the filtered tag config to work.