### PR TITLE
Add Support for Multiple Granularities in AWS Cost Exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 .DS_Store
 .venv
 *.local.*
+Pipfile.lock
+Pipfile

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ aws_daily_cost_usd{ChargeType="Usage",EnvironmentName="prod",ProjectName="myproj
 
 _ps: As the metric name indicate, the metric shows the daily costs in USD. `Daily` is based a fixed 24h time window, from UTC 00:00 to UTC 24:00. `EnvironmentName` and `ProjectName` are the custom labels that can be configured. `RegionName` is a label based on `group_by` configuration._
 
+## Supported Granularities
+
+The exporter supports different granularities for cost metrics:
+
+- **DAILY**: Exports the cost for the previous day.
+- **MONTHLY**: Exports month-to-date costs (from the first day of the current month to now).
+
+You can specify the granularity for each metric in the `exporter_config.yaml` file:
+
+```yaml
+metrics:
+  - metric_name: aws_daily_cost_usd
+    granularity: DAILY  # Valid values: DAILY, MONTHLY
+    # ... other configurations
+```
+
 ## How Does This Work
 
 AWS Cost Metrics Exporter fetches cost data from a list of AWS accounts, each of which provides a necessary IAM role for the exporter. It regularly queries the AWS [GetCostAndUsage](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetCostAndUsage.html) to get the whole AWS account's cost. It is configurable to have different queries, such as group by services and tags, merge minor cost to one single category, etc. The following figure describes how AWS Cost Metrics Exporter works.

--- a/main.py
+++ b/main.py
@@ -62,6 +62,11 @@ def validate_configs(config):
         "Tax",
         "Usage",
     ]
+    
+    valid_granularity_types = [
+        "DAILY",
+        "MONTHLY",
+    ]
 
     if len(config["target_aws_accounts"]) == 0:
         logging.error("There should be at least one target AWS account defined in the config!")
@@ -119,6 +124,16 @@ def validate_configs(config):
                 logging.error("Some label names in group_by are the same as AWS account labels!")
                 sys.exit(1)
 
+        # Validate granularity
+        if "granularity" not in config_metric:
+            logging.warning(f"Granularity not specified for metric {config_metric['metric_name']}, defaulting to DAILY")
+            config_metric["granularity"] = "DAILY"
+        elif config_metric["granularity"] not in valid_granularity_types:
+            logging.error(
+                f"Invalid granularity: {config_metric['granularity']}. It must be one of {', '.join(valid_granularity_types)}."
+            )
+            sys.exit(1)
+            
         # Validate metric_type
         if config_metric["metric_type"] not in valid_metric_types:
             logging.error(
@@ -175,7 +190,8 @@ def main(config):
             group_by=config_metric["group_by"],
             metric_type=config_metric["metric_type"],
             record_types=config_metric.get("record_types", ["Usage"]),
-            tag_filters=config_metric.get("tag_filters", None)
+            tag_filters=config_metric.get("tag_filters", None),
+            granularity=config_metric.get("granularity", "DAILY")
         )
         metric_exporters.append(metric)
 


### PR DESCRIPTION
### Summary
This PR adds support for different time granularities when fetching AWS cost data. Previously, the exporter was limited to daily cost metrics only, but now it supports both daily and monthly (month-to-date) metrics.
### Changes
- Added a granularity configuration option in exporter_config.yaml for each metric
- Implemented support for DAILY (previous day) and MONTHLY (month-to-date) granularities
- Updated date range calculation logic based on the selected granularity
- Renamed internal variable from aws_daily_cost_usd to cost_metric to be more generic
- Added validation for the granularity parameter in the configuration
- Updated metric descriptions to accurately reflect the granularity of the data
- Added documentation about supported granularities in the README
### How to Use
Configure the granularity for each metric in the exporter_config.yaml file:
```
metrics:
  - metric_name: aws_daily_cost_usd
    granularity: DAILY  # Valid values: DAILY, MONTHLY
    # ... other configurations

  - metric_name: aws_monthly_cost_by_service
    granularity: MONTHLY
    # ... other configurations
```
### Why This Matters
This enhancement provides more flexibility for users who need to monitor AWS costs across different time frames. The month-to-date metrics are particularly useful for tracking monthly budget usage and identifying cost trends before the month ends.
### Future Work
This PR establishes the foundation for adding more granularities in the future (e.g., HOURLY, MONTHLY 30 day) as needed.