### PR TITLE
feat: Add support for Hourly granularity

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ _ps: As the metric name indicate, the metric shows the daily costs in USD. `Dail
 
 The exporter supports different granularities for cost metrics:
 
+- **HOURLY**: Exports the Hourly cost over the `polling_interval_seconds` which must not exceed 14 days. Hourly granularity requires opt-in from the AWS Cost Explorer Settings page and will incur additional charges.
 - **DAILY**: Exports the cost for the previous day.
 - **MONTHLY**: Exports month-to-date costs (from the first day of the current month to now).
 
@@ -35,7 +36,7 @@ You can specify the granularity for each metric in the `exporter_config.yaml` fi
 ```yaml
 metrics:
   - metric_name: aws_daily_cost_usd
-    granularity: DAILY  # Valid values: DAILY, MONTHLY
+    granularity: DAILY  # Valid values: HOURLY, DAILY, MONTHLY. 
     # ... other configurations
 ```
 

--- a/exporter_config.yaml
+++ b/exporter_config.yaml
@@ -7,6 +7,8 @@ aws_assumed_role_name: $AWS_ASSUMED_ROLE|"" # Optional. When empty, will use the
 
 metrics:
   - metric_name: aws_daily_cost_by_service_by_account # change the metric name if needed
+    # metric_description: Daily cost by service by account
+    granularity: DAILY
     group_by:
       enabled: true
       # Cost data can be groupped using up to two different groups: DIMENSION, TAG, COST_CATEGORY.
@@ -48,6 +50,8 @@ metrics:
           - dev
 
   - metric_name: aws_daily_cost_usd # change the metric name if needed
+    # metric_description: Daily cost in USD by service by region
+    granularity: DAILY
     group_by:
       enabled: true
       # Cost data can be groupped using up to two different groups: DIMENSION, TAG, COST_CATEGORY.

--- a/main.py
+++ b/main.py
@@ -62,8 +62,9 @@ def validate_configs(config):
         "Tax",
         "Usage",
     ]
-    
+
     valid_granularity_types = [
+        "HOURLY",
         "DAILY",
         "MONTHLY",
     ]
@@ -133,7 +134,7 @@ def validate_configs(config):
                 f"Invalid granularity: {config_metric['granularity']}. It must be one of {', '.join(valid_granularity_types)}."
             )
             sys.exit(1)
-            
+
         # Validate metric_type
         if config_metric["metric_type"] not in valid_metric_types:
             logging.error(
@@ -191,7 +192,7 @@ def main(config):
             metric_type=config_metric["metric_type"],
             record_types=config_metric.get("record_types", ["Usage"]),
             tag_filters=config_metric.get("tag_filters", None),
-            granularity=config_metric.get("granularity", "DAILY")
+            granularity=config_metric.get("granularity", "DAILY"),
         )
         metric_exporters.append(metric)
 


### PR DESCRIPTION
- Added support for HOURLY granularity in exporter_config.yaml and updated related comments.
- Updated validate_configs function in main.py to include HOURLY in valid granularity types.
- Adjusted metric exporter class to handle HOURLY granularity in query_aws_cost_explorer method.
- Updated README.md to reflect the new granularity option and its implications.